### PR TITLE
Fix parse api response of notifications

### DIFF
--- a/packages/restapi/src/lib/utils/parseAPI.ts
+++ b/packages/restapi/src/lib/utils/parseAPI.ts
@@ -27,7 +27,7 @@ export function parseApiResponse(response: ApiNotificationType[]): ParsedRespons
 
     return {
       cta,
-      title: asub || notification.title || '',
+      title: asub || '',
       message: bigMessage || notification.body || '',
       icon,
       url,


### PR DESCRIPTION
fix #139

- Modifies title in return object of `parseApiResponse` to asub, or empty string if asub is falsy.