### PR TITLE
fix(sendnotification): make sender type optional field

### DIFF
--- a/packages/restapi/src/lib/types/index.ts
+++ b/packages/restapi/src/lib/types/index.ts
@@ -71,7 +71,7 @@ export type ParsedResponseType = {
 };
 
 export interface ISendNotificationInputOptions {
-  senderType: 0 | 1;
+  senderType?: 0 | 1;
   signer: any;
   type: NOTIFICATION_TYPE;
   identityType: IDENTITY_TYPE;


### PR DESCRIPTION
- Marks `senderType` as an optional field inside of `ISendNotificationInputOptions`.