### PR TITLE
fix: multi join issue in invites modal

### DIFF
--- a/packages/uiweb/src/lib/components/space/SpaceBanner/SpaceBanner.tsx
+++ b/packages/uiweb/src/lib/components/space/SpaceBanner/SpaceBanner.tsx
@@ -19,7 +19,7 @@ export interface ISpaceBannerProps {
   orientation?: 'maximized' | 'minimized' | 'pill';
   isInvite?: boolean;
   onBannerClick?: (arg: string) => void;
-  modalCallback?: any;
+  actionCallback?: any;
 }
 
 /**
@@ -38,7 +38,7 @@ export const SpaceBanner: React.FC<ISpaceBannerProps> = ({
   orientation,
   isInvite,
   onBannerClick,
-  modalCallback,
+  actionCallback,
 }) => {
   const theme = React.useContext(ThemeContext);
   const spaceData = useGetSpaceInfo(spaceId);
@@ -66,7 +66,7 @@ export const SpaceBanner: React.FC<ISpaceBannerProps> = ({
     await initSpaceObject(spaceData?.spaceId as string);
 
     if (isListener) {
-      modalCallback();
+      actionCallback();
       setSpaceWidgetId(spaceData?.spaceId as string);
     }
   };
@@ -78,7 +78,7 @@ export const SpaceBanner: React.FC<ISpaceBannerProps> = ({
       await spacesObjectRef?.current?.join();
       setSpaceWidgetId(spaceId);
       console.log('space joined');
-      modalCallback();
+      actionCallback();
     };
     joinSpaceAsSpeaker();
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
+++ b/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
@@ -10,9 +10,6 @@ export interface ISpaceInvitesProps {
   children?: React.ReactNode;
 }
 
-// temp
-let spaceId = "";
-
 export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
   children,
 }: ISpaceInvitesProps) => {
@@ -21,44 +18,9 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
 
   const containerRef = useFeedScroll(spaceRequests.apiData?.length);
 
-  const {
-    spacesObjectRef,
-    spaceObjectData,
-    initSpaceObject,
-    setSpaceWidgetId,
-    isSpeaker,
-    isListener,
-    account,
-    env,
-  } = useSpaceData();
+  const { account, env } = useSpaceData();
 
   usePushSpaceSocket({ account, env });
-
-  const handleJoinSpace = async (space: any) => {
-    await initSpaceObject(space?.spaceId as string);
-
-    if (isSpeaker) {
-      spaceId = space?.spaceId;
-    }
-    if (isListener) {
-      handleCloseModal();
-      setSpaceWidgetId(space?.spaceId as string);
-      console.log('modal to join space opened');
-    }
-  };
-
-  useEffect(() => {
-    if (!spaceObjectData?.connectionData?.local.stream || !isSpeaker) return;
-    const joinSpaceAsSpeaker = async () => {
-      console.log('joining as a speaker');
-      await spacesObjectRef?.current?.join();
-      setSpaceWidgetId(spaceId);
-      console.log('space joined');
-      handleCloseModal();
-    };
-    joinSpaceAsSpeaker();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spaceObjectData?.connectionData?.local.stream]);
 
   const handleOpenModal = () => {
     setModalOpen(true);
@@ -75,7 +37,6 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
       spaceRequests.lastPage &&
       spaceRequests.currentPage < spaceRequests.lastPage
     ) {
-      console.log('Load More Data');
       setSpaceRequests({
         currentPage: spaceRequests.currentPage + 1,
         lastPage: spaceRequests.lastPage + 1,
@@ -119,7 +80,7 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
                         spaceId={space.spaceId}
                         orientation="maximized"
                         isInvite={true}
-                        onJoin={() => handleJoinSpace(space)}
+                        modalCallback={handleCloseModal}
                       />
                     );
                   })

--- a/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
+++ b/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
@@ -21,7 +21,6 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
 
   const containerRef = useFeedScroll(spaceRequests.apiData?.length);
 
-  const [playBackUrl, setPlayBackUrl] = useState<string>('');
   const {
     spacesObjectRef,
     spaceObjectData,
@@ -39,17 +38,12 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
     await initSpaceObject(space?.spaceId as string);
 
     if (isSpeaker) {
-      // create audio stream
-      await spacesObjectRef.current.createAudioStream();
-      spaceId = space?.spaceId; // temp
+      spaceId = space?.spaceId;
     }
     if (isListener) {
-      await spacesObjectRef?.current?.join();
-      const playBackUrl = spaceObjectData.spaceDescription;
-      setPlayBackUrl(playBackUrl);
       handleCloseModal();
       setSpaceWidgetId(space?.spaceId as string);
-      console.log('space joined');
+      console.log('modal to join space opened');
     }
   };
 

--- a/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
+++ b/packages/uiweb/src/lib/components/space/SpaceInvites/SpaceInvites.tsx
@@ -8,10 +8,14 @@ import { SpaceBanner } from '../SpaceBanner';
 
 export interface ISpaceInvitesProps {
   children?: React.ReactNode;
+  actionCallback?: any;
+  onBannerClickHandler?: (arg: string) => void;
 }
 
 export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
   children,
+  actionCallback,
+  onBannerClickHandler,
 }: ISpaceInvitesProps) => {
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const { spaceRequests, setSpaceRequests } = useSpaceData();
@@ -28,6 +32,20 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
 
   const handleCloseModal = () => {
     setModalOpen(false);
+  };
+
+  const handleCustomClose = () => {
+    if (actionCallback) {
+      actionCallback();
+    };
+
+    setModalOpen(false);
+  };
+
+  const handleClick = (spaceId: string) => {
+    if (onBannerClickHandler) {
+      return onBannerClickHandler(spaceId || '');
+    }
   };
 
   const loadMoreData = () => {
@@ -80,7 +98,10 @@ export const SpaceInvites: React.FC<ISpaceInvitesProps> = ({
                         spaceId={space.spaceId}
                         orientation="maximized"
                         isInvite={true}
-                        modalCallback={handleCloseModal}
+                        actionCallback={handleCustomClose}
+                        onBannerClick={
+                          onBannerClickHandler ? handleClick : undefined
+                        }
                       />
                     );
                   })


### PR DESCRIPTION
the invite modal called the joinSpace API, which was again being called in the LiveWidget component, which led to the API being called twice.

The fix was to remove the API call from the SpaceInvite modal as the invite modal opened the LiveWidget, which by design called the joinSpace API through useEffect.

This has been tested for both Speaker as well as Listener ✅ 