### PR TITLE
fix: focus back to message input after sending the message

### DIFF
--- a/packages/uiweb/src/lib/components/chat/MessageInput/MessageInput.tsx
+++ b/packages/uiweb/src/lib/components/chat/MessageInput/MessageInput.tsx
@@ -142,6 +142,11 @@ export const MessageInput: React.FC<MessageInputProps> = ({
     }
   }, [textAreaRef, typedMessage]);
 
+  useEffect(() => {
+    if (!loading && textAreaRef.current) {
+      textAreaRef.current.focus();
+    }
+  }, [loading, textAreaRef]);
   //need to do something about fetching connectedUser in every component
   useEffect(() => {
     (async () => {


### PR DESCRIPTION
After sending message in the chat ui. component, the focus will go off the message input. This PR fixes that