### PR TITLE
fix: Added ethersV6SignerType in uiweb signer types

### DIFF
--- a/packages/examples/sdk-frontend-react/src/app/ChatSupportTest.tsx
+++ b/packages/examples/sdk-frontend-react/src/app/ChatSupportTest.tsx
@@ -35,8 +35,7 @@ export const ChatSupportTest = () => {
     <SupportChat
   
       signer={librarySigner}
-      supportAddress="fabio.eth"
-      apiKey="tAWEnggQ9Z.UaDBNjrvlJZx3giBTIQDcT8bKQo1O1518uF1Tea7rPwfzXv2ouV5rX9ViwgJUrXm"
+      supportAddress="richa.eth"
       env={env}
       greetingMsg="How can i help you?"
       theme={lightTheme}

--- a/packages/uiweb/src/lib/components/supportChat/AddressInfo.tsx
+++ b/packages/uiweb/src/lib/components/supportChat/AddressInfo.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { SupportChatPropsContext } from '../../context';
-import { Constants, InfuraAPIKey, allowedNetworks } from '../../config';
+import { Constants, ENV, InfuraAPIKey, allowedNetworks } from '../../config';
 import { copyToClipboard, pCAIP10ToWallet, resolveNewEns } from '../../helpers';
 import { CopySvg } from '../../icons/CopySvg';
 import { ethers } from 'ethers';
@@ -12,15 +12,15 @@ export const AddressInfo: React.FC = () => {
   const [user, setUser] = useState<any>({});
   const [isCopied, setIsCopied] = useState<boolean>(false);
   const walletAddress = pCAIP10ToWallet(supportAddress);
-  const l1ChainId = allowedNetworks[env].includes(1) ? 1 : 5;
-  const provider = new ethers.providers.InfuraProvider(l1ChainId, InfuraAPIKey);
+  // const l1ChainId = (allowedNetworks[env]?.includes(1)) ? 1 : 5;
+  // const provider = new ethers.providers.InfuraProvider(l1ChainId, InfuraAPIKey);
 
   useEffect(() => {
     const getUser = async () => {
 if(pushUser){
   const user = await pushUser.info();
- const ensNameResult = await resolveNewEns(supportAddress, provider) 
-  setEnsName(ensNameResult!)
+//  const ensNameResult = await resolveNewEns(supportAddress, provider) 
+//   setEnsName(ensNameResult!)
       setUser(user);
 }
       

--- a/packages/uiweb/src/lib/types/index.ts
+++ b/packages/uiweb/src/lib/types/index.ts
@@ -52,19 +52,30 @@ export interface ITheme {
   moduleColor?: string;
 }
 
-type ethersV5SignerType = {
+export type ethersV5SignerType = {
   _signTypedData: (
     domain: TypedDataDomain,
     types: Record<string, Array<TypedDataField>>,
     value: Record<string, any>
   ) => Promise<string>;
-  getChainId: () => Promise<number>;
   getAddress: () => Promise<string>;
-  signMessage: (message: Bytes | string) => Promise<string>;
+  signMessage: (message: Uint8Array | string) => Promise<string>;
   privateKey?: string;
-  provider?: providers.Provider;
+  provider?: any;
 };
-type viemSignerType = {
+
+export type ethersV6SignerType = {
+  signTypedData: (
+    domain: TypedDataDomain,
+    types: Record<string, Array<TypedDataField>>,
+    value: Record<string, any>
+  ) => Promise<string>;
+  getAddress: () => Promise<string>;
+  signMessage: (message: Uint8Array | string) => Promise<string>;
+  privateKey?: string;
+  provider?: any;
+};
+export type viemSignerType = {
   signTypedData: (args: {
     account: any;
     domain: any;
@@ -80,10 +91,10 @@ type viemSignerType = {
   }) => Promise<`0x${string}`>;
   account: { [key: string]: any };
   privateKey?: string;
-  provider?: providers.Provider;
+  provider?: any;
 };
 
-export type SignerType = ethersV5SignerType | viemSignerType;
+export type SignerType =  ethersV5SignerType| ethersV6SignerType| viemSignerType;;
 
 export type ParsedNotificationType = ParsedResponseType & {
   channel:string;


### PR DESCRIPTION
Solves the following issue when building:
```
Error during bundle: Error: /Users/shoaibmohammed/Desktop/work/push/push-sdk/packages/uiweb/src/lib/dataProviders/SpaceDataProvider.tsx(333,5): semantic error TS2322: Type 'SignerType' is not assignable to type 'SignerType | undefined'.
  Type 'ethersV5SignerType' is not assignable to type 'SignerType | undefined'.
    Property 'getChainId' is missing in type 'import("/Users/shoaibmohammed/Desktop/work/push/push-sdk/dist/packages/restapi/src/lib/types/index").ethersV5SignerType' but required in type 'ethersV5SignerType'.
```